### PR TITLE
Request to Add Optiplex 3060 Micro offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
     - 5491 https://github.com/tadghh/Dell-unlock-undervolting/issues/3 Offset: 0x659
 - Precision 
 	- 5520 [#4](https://github.com/tadghh/Dell-unlock-undervolting/issues/4) Offset: 0x59C 
+- Optiplex
+	- 3060 Micro [#5](https://github.com/tadghh/Dell-unlock-undervolting/issues/5) Offset: 0x65A
 
 ### ✔️ Compatibility
 


### PR DESCRIPTION
I'm creating a pull request as instructed on your README.md to add another confirmed compatible device with the Undervolting Unlock BIOS mod. 

I tested it on my Optiplex 3060 Micro which uses the offset 0x65A as mentioned on the [issue I opened in conjunction with this pull request](https://github.com/tadghh/Dell-unlock-undervolting/issues/5).