### PR TITLE
Unlocking Voltage Control - Dell Precision 5530, BIOS 1.47

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 |           | 7490         | [@prifak](https://github.com/tadghh/Dell-unlock-undervolting/issues/10)                   | 0x5DC   |
 | **Precision** | 3630     | [@msprengholz](https://github.com/tadghh/Dell-unlock-undervolting/issues/14)              | 0x65C   |
 |           | 5520         | [@dimasafonis](https://github.com/tadghh/Dell-unlock-undervolting/issues/4)               | 0x59C   |
+|           | 5530         | [@Grenvals](https://github.com/tadghh/Dell-unlock-undervolting/issues/19) CFG Lock: 0x3E - Tested on: BIOS 1.17,1.47   | 0x59C   |
 | **Optiplex** | 3060 Micro | [@RonK-0](https://github.com/tadghh/Dell-unlock-undervolting/issues/5)                    | 0x65A   |
 
 


### PR DESCRIPTION
Unlocking Voltage Control - Dell Precision 5530, BIOS 1.47

📌 Changes:
Added support for Dell Precision 5530
CFG Lock offset: 0x3E
Control/MSR-related offset: 0x59C
Verified BIOS versions: 1.17, 1.47
Reference issue: [#19](https://github.com/tadghh/Dell-unlock-undervolting/issues/19) (@Grenvals)

✅ Results:
CFG Lock successfully unlocked
Undervolting functionality restored after patching
Stable operation confirmed on tested BIOS versions

🧪 Testing:
Tested on a physical Dell Precision 5530 unit
Patch applies without errors
System remains stable after modifications

Closes #19

<img width="965" height="737" alt="image" src="https://github.com/user-attachments/assets/7d5f6dbc-8afa-42d6-ab43-cc6a737ce750" />
